### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["amd64", "emulation", "disassembly"]
 license = "0BSD"
 name = "regmap"
 readme = "README.md"
-repository = "https://www.github.com/iximeow/regmap/"
+repository = "https://github.com/iximeow/regmap/"
 version = "0.1.0"
 
 [profile.dev]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96